### PR TITLE
Elliptic curves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,9 @@
 version = 3
 
 [[package]]
+name = "elliptic-curves"
+version = "0.1.0"
+
+[[package]]
 name = "finite-fields"
 version = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,5 @@
 [workspace]
-members = ["finite-fields"]
+members = [
+	"finite-fields",
+	"elliptic-curves",
+]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Rueth
 
-1. Finite Fields
+## Finite Fields
 
+
+## Elliptic Curves

--- a/elliptic-curves/Cargo.toml
+++ b/elliptic-curves/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "elliptic-curves"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/elliptic-curves/src/lib.rs
+++ b/elliptic-curves/src/lib.rs
@@ -1,0 +1,50 @@
+#[derive(PartialEq)]
+pub struct Point {
+    pub x: i32,
+    pub y: i32,
+    pub a: i32,
+    pub b: i32,
+}
+
+impl Point {
+    pub fn new(x: i32, y: i32, a: i32, b: i32) -> Self {
+        if y.pow(2) != x.pow(3) + (a * x) + b {
+            panic!("({}, {}) is not on the curve", x, y);
+        }
+
+        Self { a, b, x, y }
+    }
+
+    pub fn equal(&self, other: Option<Point>) -> bool {
+        *self == other.unwrap()
+    }
+
+    pub fn not_equal(&self, other: Option<Point>) -> bool {
+        *self != other.unwrap()
+    }
+}
+
+pub fn add(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{add, Point};
+
+    #[test]
+    fn test_add() {
+        let a = 1;
+        let b = 1;
+
+        assert_eq!(2, add(a, b));
+    }
+
+    #[test]
+    fn test_equal() {
+        let point1 = Point::new(-1, -1, 5, 7);
+        let point2 = Point::new(-1, -1, 5, 7);
+
+        assert!(point1.equal(Some(point2)));
+    }
+}

--- a/elliptic-curves/src/lib.rs
+++ b/elliptic-curves/src/lib.rs
@@ -1,15 +1,18 @@
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub struct Point {
-    pub x: i32,
-    pub y: i32,
+    pub x: Option<i32>,
+    pub y: Option<i32>,
     pub a: i32,
     pub b: i32,
 }
 
 impl Point {
-    pub fn new(x: i32, y: i32, a: i32, b: i32) -> Self {
-        if y.pow(2) != x.pow(3) + (a * x) + b {
-            panic!("({}, {}) is not on the curve", x, y);
+    // x.is_none() && y.is_none() -> the point at infinity
+    pub fn new(x: Option<i32>, y: Option<i32>, a: i32, b: i32) -> Self {
+        if x.is_some() && y.is_some() {
+            if y.unwrap().pow(2) != x.unwrap().pow(3) + (a * x.unwrap()) + b {
+                panic!("({}, {}) is not on the curve", x.unwrap(), y.unwrap());
+            }
         }
 
         Self { a, b, x, y }
@@ -22,29 +25,51 @@ impl Point {
     pub fn not_equal(&self, other: Option<Point>) -> bool {
         *self != other.unwrap()
     }
-}
 
-pub fn add(a: u32, b: u32) -> u32 {
-    a + b
+    pub fn add(&self, other: Point) -> Self {
+        if self.a != other.a || self.b != other.b {
+            panic!("Points {:?}, {:?} are not on the same curve", self, other);
+        }
+
+        match (self.x, other.x) {
+            (Some(self_x), Some(other_x)) if self_x == other_x && self.y != other.y => {
+                return Self {
+                    x: None,
+                    y: None,
+                    a: self.a,
+                    b: self.b,
+                }
+            }
+            (Some(_), None) => return *self,
+            (None, Some(_)) => return other,
+            _ => Self {
+                x: self.x,
+                y: self.y,
+                a: self.a,
+                b: self.b,
+            },
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{add, Point};
-
-    #[test]
-    fn test_add() {
-        let a = 1;
-        let b = 1;
-
-        assert_eq!(2, add(a, b));
-    }
+    use crate::Point;
 
     #[test]
     fn test_equal() {
-        let point1 = Point::new(-1, -1, 5, 7);
-        let point2 = Point::new(-1, -1, 5, 7);
+        let point1 = Point::new(Some(-1), Some(-1), 5, 7);
+        let point2 = Point::new(Some(-1), Some(-1), 5, 7);
 
         assert!(point1.equal(Some(point2)));
+    }
+
+    #[test]
+    fn test_add() {
+        let point1 = Point::new(Some(-1), Some(-1), 5, 7);
+        let point2 = Point::new(Some(-1), Some(1), 5, 7);
+        let inf = Point::new(None, None, 5, 7);
+
+        assert_eq!(point1.add(point2), inf);
     }
 }

--- a/elliptic-curves/src/lib.rs
+++ b/elliptic-curves/src/lib.rs
@@ -32,24 +32,33 @@ impl Point {
         }
 
         match (self.x, other.x) {
-            (Some(self_x), Some(other_x)) if self_x == other_x && self.y != other.y => {
-                return Self {
-                    x: None,
-                    y: None,
-                    a: self.a,
-                    b: self.b,
-                }
-            }
+            (Some(self_x), Some(other_x)) if self_x == other_x && self.y != other.y => Self {
+                x: None,
+                y: None,
+                a: self.a,
+                b: self.b,
+            },
             (Some(self_x), Some(other_x)) if self_x != other_x => {
                 let s = (other.y.unwrap() - self.y.unwrap()) / (other.x.unwrap() - self.x.unwrap());
                 let x3 = s.pow(2) - self.x.unwrap() - other.x.unwrap();
                 let y3 = s * (self.x.unwrap() - x3) - self.y.unwrap();
-                return Self {
+                Self {
                     x: Some(x3),
                     y: Some(y3),
                     a: self.a,
                     b: self.b,
-                };
+                }
+            }
+            (Some(self_x), Some(other_x)) if self_x == other_x && self.y == other.y => {
+                let s = (3 * self_x.pow(2) + self.a) / (2 * self.y.unwrap());
+                let x3 = s.pow(2) - 2 * self_x;
+                let y3 = s * (self_x - x3) - self.y.unwrap();
+                Self {
+                    x: Some(x3),
+                    y: Some(y3),
+                    a: self.a,
+                    b: self.b,
+                }
             }
             (Some(_), None) => return *self,
             (None, Some(_)) => return other,
@@ -83,9 +92,17 @@ mod tests {
 
         assert_eq!(point1.add(point2), inf);
 
+        // x1 != x2
         point1 = Point::new(Some(2), Some(5), 5, 7);
         point2 = Point::new(Some(-1), Some(-1), 5, 7);
         let point3 = Point::new(Some(3), Some(-7), 5, 7);
+
+        assert_eq!(point1.add(point2), point3);
+
+        // p1 == p2
+        point1 = Point::new(Some(-1), Some(-1), 5, 7);
+        point2 = Point::new(Some(-1), Some(-1), 5, 7);
+        let point3 = Point::new(Some(18), Some(77), 5, 7);
 
         assert_eq!(point1.add(point2), point3);
     }

--- a/elliptic-curves/src/lib.rs
+++ b/elliptic-curves/src/lib.rs
@@ -9,9 +9,9 @@ pub struct Point {
 impl Point {
     // x.is_none() && y.is_none() -> the point at infinity
     pub fn new(x: Option<i32>, y: Option<i32>, a: i32, b: i32) -> Self {
-        if x.is_some() && y.is_some() {
-            if y.unwrap().pow(2) != x.unwrap().pow(3) + (a * x.unwrap()) + b {
-                panic!("({}, {}) is not on the curve", x.unwrap(), y.unwrap());
+        if let (Some(x_value), Some(y_value)) = (x, y) {
+            if y_value.pow(2) != x_value.pow(3) + (a * x_value) + b {
+                panic!("({}, {}) is not on the curve", x_value, y_value);
             }
         }
 
@@ -60,8 +60,8 @@ impl Point {
                     b: self.b,
                 }
             }
-            (Some(_), None) => return *self,
-            (None, Some(_)) => return other,
+            (Some(_), None) => *self,
+            (None, Some(_)) => other,
             _ => Self {
                 x: self.x,
                 y: self.y,

--- a/elliptic-curves/src/lib.rs
+++ b/elliptic-curves/src/lib.rs
@@ -40,6 +40,17 @@ impl Point {
                     b: self.b,
                 }
             }
+            (Some(self_x), Some(other_x)) if self_x != other_x => {
+                let s = (other.y.unwrap() - self.y.unwrap()) / (other.x.unwrap() - self.x.unwrap());
+                let x3 = s.pow(2) - self.x.unwrap() - other.x.unwrap();
+                let y3 = s * (self.x.unwrap() - x3) - self.y.unwrap();
+                return Self {
+                    x: Some(x3),
+                    y: Some(y3),
+                    a: self.a,
+                    b: self.b,
+                };
+            }
             (Some(_), None) => return *self,
             (None, Some(_)) => return other,
             _ => Self {
@@ -66,10 +77,16 @@ mod tests {
 
     #[test]
     fn test_add() {
-        let point1 = Point::new(Some(-1), Some(-1), 5, 7);
-        let point2 = Point::new(Some(-1), Some(1), 5, 7);
+        let mut point1 = Point::new(Some(-1), Some(-1), 5, 7);
+        let mut point2 = Point::new(Some(-1), Some(1), 5, 7);
         let inf = Point::new(None, None, 5, 7);
 
         assert_eq!(point1.add(point2), inf);
+
+        point1 = Point::new(Some(2), Some(5), 5, 7);
+        point2 = Point::new(Some(-1), Some(-1), 5, 7);
+        let point3 = Point::new(Some(3), Some(-7), 5, 7);
+
+        assert_eq!(point1.add(point2), point3);
     }
 }

--- a/elliptic-curves/src/main.rs
+++ b/elliptic-curves/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/elliptic-curves/src/main.rs
+++ b/elliptic-curves/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
## Elliptic Curves

### Definition
- y ^ 2 = x ^ 3 + ax + b
- symmetric over the x-axis
- elliptic curve used in Bitcoin is called secp256k1 -> y ^ 2 = x ^ 3 + 7 (constants a = 0, b = 7)

### Point Addition
- we can do an operation on two of the points on the curve and get a third point, also on the curve

### Math of Point Addition
Point addition satisfies certain properties that we associate with addition, such as 
1. Identity
2. Commutativity
3. Associativity
4. Invertibillty

#### Identity
there's zero    
`I + A = A`   
there exists some point I that, when added to a point A, results in A:
*point at infinty*

#### Commutativity
A + B = B + A






